### PR TITLE
Enhanced goal loaning math

### DIFF
--- a/src/app/goal-list-item/goal-list-item.component.html
+++ b/src/app/goal-list-item/goal-list-item.component.html
@@ -2,7 +2,7 @@
   [ngClass]="{'goal-item-complete': goal.isComplete(),
               'goal-item-funded': goal.isFunded(),
               'goal-item-overdrawn': goal.isOverdrawn(),
-              'goal-item-affordable': goal.budget.checkBalance(goal) && !goal.isOverdrawn()}">
+              'goal-item-affordable': goalAffordable()}">
 
   <h2 class="inline">{{goal.label}}</h2>
   <div class="inline">
@@ -33,8 +33,8 @@
     [value]="100 * goal.current / goal.target">
   </mat-progress-bar>
 
-  <p *ngIf="goal.isFunded() && !goal.budget.checkBalance(goal)">
-    Note: This goal has reached its target, but you may not have sufficient balance to purchase it.
+  <p *ngIf="goalImpeded()">
+    Note: This goal has reached its target, but this budget does not have sufficient saved balance to purchase it.
   </p>
 
   <div

--- a/src/app/goal-list-item/goal-list-item.component.ts
+++ b/src/app/goal-list-item/goal-list-item.component.ts
@@ -21,6 +21,25 @@ export class GoalListItemComponent {
 
   constructor(public budgets: Budgets) { }
 
+  public goalAffordable(): boolean {
+    if (this.goal.isOverdrawn()) {
+      return false;
+    }
+    if (this.goal.isFunded() && !this.goalImpeded()) {
+      return true;
+    }
+
+    // Calculate the loanable balance, less the loanable amount for this goal to avoid double-counting
+    const available_balance = this.goal.budget.loanableBalance() - this.goal.loanableBalance();
+
+    return this.goal.target - this.goal.current <= available_balance;
+  }
+
+  public goalImpeded(): boolean {
+    // Check if the goal is fully funded, but prevented from being purchased due to insufficient saved balance
+    return this.goal.isFunded() && this.goal.target > this.goal.budget.totalBalance();
+  }
+
   public archive() {
     this.goal.budget.archive(this.goal);
     this.budgets.save(this.goal.budget);

--- a/src/app/goal-list-item/goal-list-item.component.ts
+++ b/src/app/goal-list-item/goal-list-item.component.ts
@@ -29,8 +29,8 @@ export class GoalListItemComponent {
       return true;
     }
 
-    // Calculate the loanable balance, less the loanable amount for this goal to avoid double-counting
-    const available_balance = this.goal.budget.loanableBalance() - this.goal.loanableBalance();
+    // Calculate the loanable balance that might be able to complete this goal
+    const available_balance = this.goal.budget.loanableBalance(this.goal);
 
     return this.goal.target - this.goal.current <= available_balance;
   }

--- a/src/app/purchase-goal-item/purchase-goal-item.component.html
+++ b/src/app/purchase-goal-item/purchase-goal-item.component.html
@@ -24,12 +24,12 @@
   </button>
 
   <p *ngIf="exceedAccrued()">
-    The cost is greater than the goal's currently saved balance. The difference will count against the total amount saved, and this goal will be kept active until the saved balance reaches the purchase cost.
+    The cost is greater than this goal's currently saved balance, and purchasing will borrow the difference from other goals. After purchasing this goal will be kept active until its balance reaches the purchase cost.
   </p>
   <p *ngIf="impedeGoal()">
-    Purchasing will reduce this budget's total saved amount available to be less than the amount already allocated for at least one other goal, and may prevent being able to purchase that goal or goals temporarily.
+    Purchasing this goal will borrow more from other goals than can be safely loaned out, and may result in another goal not having sufficient savings available even after being fully funded.
   </p>
   <p *ngIf="exceedTotalBalance()">
-    <em>Note:</em> The cost is greater than this budget's total saved amount available.
+    <em>Note:</em> The cost is greater than the total amount saved for this budget.
   </p>
 </form>

--- a/src/app/purchase-goal-item/purchase-goal-item.component.html
+++ b/src/app/purchase-goal-item/purchase-goal-item.component.html
@@ -23,13 +23,16 @@
     Cancel
   </button>
 
-  <p *ngIf="exceedAccrued()">
-    The cost is greater than this goal's currently saved balance, and purchasing will borrow the difference from other goals. After purchasing this goal will be kept active until its balance reaches the purchase cost.
+  <p *ngIf="exceedAccrued() && !impedeGoal()">
+    The cost is greater than this goal's currently saved balance, purchasing will safely borrow the difference from other goals.
   </p>
   <p *ngIf="impedeGoal()">
-    Purchasing this goal will borrow more from other goals than can be safely loaned out, and may result in another goal not having sufficient savings available even after being fully funded.
+    This cost is greater than this goal's currently saved balance, and the difference cannot safely be borrowed from other goals. Purchasing at this cost may delay other goals, even after they are fully funded.
+  </p>
+  <p *ngIf="exceedAccrued()">
+    After purchasing this goal will be kept active until its balance reaches the purchase cost.
   </p>
   <p *ngIf="exceedTotalBalance()">
-    <em>Note:</em> The cost is greater than the total amount saved for this budget.
+    <em>Note:</em> The cost is greater than the available amount saved for this budget.
   </p>
 </form>

--- a/src/app/purchase-goal-item/purchase-goal-item.component.html
+++ b/src/app/purchase-goal-item/purchase-goal-item.component.html
@@ -27,12 +27,12 @@
     The cost is greater than this goal's currently saved balance, purchasing will safely borrow the difference from other goals.
   </p>
   <p *ngIf="impedeGoal()">
-    This cost is greater than this goal's currently saved balance, and the difference cannot safely be borrowed from other goals. Purchasing at this cost may delay other goals, even after they are fully funded.
+    This cost is greater than this goal's currently saved balance, and borrowing the difference from other goals may result in the amount borrowed still being outstanding when they are fully funded. This could potentially delay other goals' purchase, even once fully funded.
   </p>
   <p *ngIf="exceedAccrued()">
-    After purchasing this goal will be kept active until its balance reaches the purchase cost.
+    After purchase, this goal will be kept active until it is fully funded and the saved balance reaches the purchase cost.
   </p>
   <p *ngIf="exceedTotalBalance()">
-    <em>Note:</em> The cost is greater than the available amount saved for this budget.
+    <em>Note:</em> The cost is greater than the available amount saved across all other goals for this budget.
   </p>
 </form>

--- a/src/app/purchase-goal-item/purchase-goal-item.component.ts
+++ b/src/app/purchase-goal-item/purchase-goal-item.component.ts
@@ -47,7 +47,7 @@ export class PurchaseGoalItemComponent implements OnInit {
 
   public impedeGoal(): boolean {
     // Calculate the loanable balance, less the loanable amount for this goal to avoid double-counting
-    const available_balance = this.goal.budget.loanableBalance() - this.goal.loanableBalance();
+    const available_balance = this.goal.budget.loanableBalance(this.goal);
 
     return (this.cost * 100) - this.goal.current > available_balance;
   }

--- a/src/app/purchase-goal-item/purchase-goal-item.component.ts
+++ b/src/app/purchase-goal-item/purchase-goal-item.component.ts
@@ -46,8 +46,9 @@ export class PurchaseGoalItemComponent implements OnInit {
   }
 
   public impedeGoal(): boolean {
-    // Return True if purchasing this goal for cost would cause total saved balance to be below the total allocated to another goal
-    const estimatedBalance = this.goal.budget.totalBalance() - this.cost * 100;
-    return this.goal.budget.goals.some(goal => goal !== this.goal && goal.current > estimatedBalance);
+    // Calculate the loanable balance, less the loanable amount for this goal to avoid double-counting
+    const available_balance = this.goal.budget.loanableBalance() - this.goal.loanableBalance();
+
+    return (this.cost * 100) - this.goal.current > available_balance;
   }
 }

--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -52,8 +52,11 @@ export class Budget implements IBudget {
     }).reduce((a, b) => a + b, 0);
   }
 
-  public checkBalance(goal: Goal): boolean {
-    return goal.target < this.totalBalance();
+  public loanableBalance(): number {
+    // Calculate the total amount that can be loaned from goals
+    return this.goals.reduce<number>((sum: number, goal: Goal) => {
+      return sum + goal.loanableBalance();
+    }, 0);
   }
 
   public delete(goal: Goal) {

--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -65,8 +65,8 @@ export class Budget implements IBudget {
     // Each goal can only contribute to bring the loan up to its own limit, but doing so does help the burden on higher-limit goals.
 
     // To calculate what can be safely loaned:
-    // - Calculate how much of each loaning gaol is already allocated in order of closest to completion to furthest
-    // - In case the user is over-leveraged, repeat the process from furthest to completion back, choosing which goals to over-leverage
+    // - Calculate how much of each loaning goal is already allocated in order of closest to completion to furthest
+    // - In case a goal is over-leveraged, repeat the process from furthest to completion back, choosing which goals to over-leverage
     // - Once each goal's available balance has been calculated, iterate across all goals to determine what the most can be loaned
     //   (Ensuring that no goal contributes more than it can, or to a total beyond its remaining goal)
 

--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -52,11 +52,73 @@ export class Budget implements IBudget {
     }).reduce((a, b) => a + b, 0);
   }
 
-  public loanableBalance(): number {
-    // Calculate the total amount that can be loaned from goals
-    return this.goals.reduce<number>((sum: number, goal: Goal) => {
-      return sum + goal.loanableBalance();
-    }, 0);
+  public loanableBalance(recipient: Goal): number {
+    // Calculating how much can be safely loaned to a goal is relatively complicated
+    // To help simplify the already complex relationships, we assume that all goals accrue savings at the same rate.
+    // (So long as purchased goals are ranked above non-purchased goals, this is safely a conservative assumption)
+    // A goal can loan out to other goals in total the amount that it has saved, but in order to ensure that the necessary balance is
+    //  available it cannot lend to any single goal more than the amount it has remaining to be funded.
+    // Limiting each loan to that amount ensures that the recipient will have accrued the amount loaned before the loaning goal is funded.
+    // e.g., a goal that has $9 saved out of $10 can lend out $9 total, but only for goals that are short $1 at a time.
+    // This will ensure that when example goal reaches $10 saved, all of the $1 loans will have been repaid and the $10 is available.
+    // This means goals can contribute a partial amount for a loan, but not additively...
+    // Each goal can only contribute to bring the loan up to its own limit, but doing so does help the burden on higher-limit goals.
+
+    // To calculate what can be safely loaned:
+    // - Calculate how much of each loaning gaol is already allocated in order of closest to completion to furthest
+    // - In case the user is over-leveraged, repeat the process from furthest to completion back, choosing which goals to over-leverage
+    // - Once each goal's available balance has been calculated, iterate across all goals to determine what the most can be loaned
+    //   (Ensuring that no goal contributes more than it can, or to a total beyond its remaining goal)
+
+    // liabilities is a list of [amount loaned, amount accounted for]
+    const liabilities = this.goals.filter(
+      goal => goal.isOverdrawn()
+    ).map<[number, number]>(
+      goal => [goal.target - goal.current, 0]
+    );
+    // loaners is a list of [available to lend, max per loan]
+    const loaners = this.goals.filter(
+      // Only use goals that haven't been purchased (That have savings to loan) and aren't funded (That don't need their savings directly)
+      goal => !goal.isPurchased() && !goal.isFunded() && goal !== recipient
+    ).map<[number, number]>(
+      goal => [goal.current, goal.target - goal.current]
+    ).sort((a, b) => a[1] - b[1]);
+
+    // Calculate what portion of each loaning goal is already earmarked
+    for (const loanerTuple of loaners) {
+      const [remainder, cap] = loanerTuple;
+      for (const loaneeTuple of liabilities) {
+        const [target, current] = loaneeTuple;
+        const margin = Math.min(remainder, cap, target - current);
+        // Update the values in place so it persists across iterations
+        // Update the current value for the loanee, to reflect it received a contribution
+        loaneeTuple[1] += margin;
+        // Update the remainder value for the loaner, to reflect it has less available to lend
+        loanerTuple[0] -= margin;
+      }
+    }
+    // Repeat the same process backwards, in case any loanees still have an outstanding balance
+    // (This would happen if a goal is purchased for more than could be safely loaned)
+    // This time, we can't cap at the goal's remaining value - these goals may end up having been over leveraged.
+    // Operating in reverse means the goals that are over leveraged have the longest amount of time to make up the gap in other ways.
+    ////////
+    // TODO
+    ////////
+
+    // Calculate how much can be contributed from remaining balances, ensuring that no goal pushes the total above its per-loan cap.
+    return loaners.reduce(
+      (sum, loaner) => Math.max(
+        sum,
+        Math.min(
+          // Return the lesser of the max value this goal can contribute up to,
+          // and what this goal has left to add to the running total sum
+          // If the goal doesn't have enough saved to max itself out, it will contribute as much as it can to help.
+          loaner[1],
+          sum + loaner[0]
+        )
+      ),
+      0
+    );
   }
 
   public delete(goal: Goal) {

--- a/src/app/shared/models/goal.model.ts
+++ b/src/app/shared/models/goal.model.ts
@@ -129,20 +129,4 @@ export class Goal implements IGoal {
     // A goal is overdrawn if it was purchased but still has yet to reach its goal.
     return this.isPurchased() && !this.isFunded();
   }
-
-  public loanableBalance(): number {
-    // A goal can loan however much it has earmarked, so long as the loan will not prevent the goal
-    //  from being purchased when fully funded.
-    // We assume that the loaning goal will receive at least as much per contribution as the goals
-    //  it is loaning from, so it is safe to loan out less than what the goal needs to be funded.
-    // Goals that are already negative (And so have outstanding loans from other goals) will count
-    //  against the loanable balance.
-    if (this.isPurchased()) {
-      // The goal has already been purchased, so count any outstanding balance against our total
-      return this.current - this.target;
-    } else {
-      // The goal can loan whatever it has earmarked, up to the amount it needs to be funded.
-      return Math.min(this.current, this.target - this.current);
-    }
-  }
 }

--- a/src/app/shared/models/goal.model.ts
+++ b/src/app/shared/models/goal.model.ts
@@ -129,4 +129,20 @@ export class Goal implements IGoal {
     // A goal is overdrawn if it was purchased but still has yet to reach its goal.
     return this.isPurchased() && !this.isFunded();
   }
+
+  public loanableBalance(): number {
+    // A goal can loan however much it has earmarked, so long as the loan will not prevent the goal
+    //  from being purchased when fully funded.
+    // We assume that the loaning goal will receive at least as much per contribution as the goals
+    //  it is loaning from, so it is safe to loan out less than what the goal needs to be funded.
+    // Goals that are already negative (And so have outstanding loans from other goals) will count
+    //  against the loanable balance.
+    if (this.isPurchased()) {
+      // The goal has already been purchased, so count any outstanding balance against our total
+      return this.current - this.target;
+    } else {
+      // The goal can loan whatever it has earmarked, up to the amount it needs to be funded.
+      return Math.min(this.current, this.target - this.current);
+    }
+  }
 }


### PR DESCRIPTION
This extends the math used to calculate when a goal can be purchased despite not being fully funded. The math is... fairly complex, but aims to be safe in that any time a goal is marked as fundable (With a blue tint), purchasing that goal should never result in a situation where goals reach fully funded but do not have enough saved to be bought.

The logic is based on a few ideas:
- Purchased goals are ranked above non-purchased goals (Later this may be enforced automatically)
- Higher ranked goals receive at least as much per contribution as goals below them
- Goals can loan their saved balance to multiple goals, but no loan they make can be greater than what that goal has left until funded.

So, a goal with $9 saved out of $10 could loan out $9 in total, but never more than $1 to any goal. If it were to make 9 loans of $1 each, so long as the goals those loans were to receive more per contribution than the example goal does, we can know that by the time the example goal is dispersed the $1 to reach $10 out of $10, then all of the loaning goals must have also been dispersed at least $1 to replenish the $9 that was loaned.

Two goals can combine a loan, but not in a simply additive way. For example, two $9 out of $10 goals can only loan $1, as more than that would risk only having $19 available when they receive the final $1 dispersement, instead of the earmarked $20. However, a $9 out of $10 and $1 out of $10 goal can combine to loan $2, as the $1 out of $10 will not be fully funded until well after a sufficient amount has been dispersed to recover the amount loaned from the $9 out of $10 goal.

If a goal has been purchased without any other goals that have sufficient balance to safely loan the difference, this is considered "over-leveraged" and the uncovered difference is taken from goals with the greatest amount remaining until funded. Because the logic for this process is conservative and assumes loaners are distributed at the same proportion as the goals they loan to (Ignoring the 1/n ratio), in many cases this margin may be fulfilled (Or able to be covered by borrowing from newer goals) by the time the later goals are funded.