### PR TITLE
Balance loaning for larger goals

### DIFF
--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -164,7 +164,7 @@ export class Budget implements IBudget {
     }
 
     // Calculate how much can be contributed from remaining balances, ensuring that no goal pushes the total above its per-loan cap.
-    const recipientLoaner = loaners.find(loaner => loaner.goal === recipient)
+    const recipientLoaner = loaners.find(loaner => loaner.goal === recipient);
     return (recipientLoaner ? recipientLoaner.available : recipient.current) + loaners.filter(
         loaner => loaner.goal !== recipient
       ).sort(

--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -164,16 +164,18 @@ export class Budget implements IBudget {
     }
 
     // Calculate how much can be contributed from remaining balances, ensuring that no goal pushes the total above its per-loan cap.
-    return loaners.reduce(
-      (sum, loaner) => Math.max(
-        sum,
-        Math.min(
+    const recipientLoaner = loaners.find(loaner => loaner.goal === recipient)
+    return (recipientLoaner ? recipientLoaner.available : recipient.current) + loaners.filter(
+        loaner => loaner.goal !== recipient
+      ).sort(
+        (a, b) => a.goal.target - b.goal.target
+      ).reduce(
+      (sum, loaner) => Math.min(
           // Return the lesser of the max this goal can contribute up to,
           // and what this goal has savings left to add to the running sum.
           // If the goal doesn't have enough saved to max itself out, it will contribute whatever it can to help.
           loaner.goal.target,
-          sum + (loaner.goal === recipient ? loaner.available : Math.min(loaner.available, loaner.maxLoan))
-        )
+          sum + Math.min(loaner.available, loaner.maxLoan)
       ),
       0
     );


### PR DESCRIPTION
Loaning was previously fixed to prevent goals from loaning more than their max goal amount, but this change led to large goals receiving disproportionately low support from smaller goals. This tweaks the fix slightly, and should enable goals to retain balance necessary for themselves, while also maximally allowing them to safely support other goals.

There is a chance that this will incorrectly over-report the available balance for goals when the total balance is below the goal's currently saved balance.