### PR TITLE
Allow goals to be paused

### DIFF
--- a/src/app/edit-goal-item/edit-goal-item.component.html
+++ b/src/app/edit-goal-item/edit-goal-item.component.html
@@ -26,15 +26,25 @@
   </span>
 
   <div *ngIf="!this.goal?.purchased">
-    <label for="goalEarmark">
-      Earmark
+    <strong>Goal Behavior</strong>
+    <br />
+    <input id="goalBehaviorDefault" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="">
+    <label for="goalBehaviorDefault"
+      title="By default, goals will loan other goals funds safely, in a way that they can be purchased once fully funded">
+      Normal ⓘ
     </label>
-    <input
-      id="goalEarmark"
-      name="goalEarmark"
-      type="checkbox"
-      [(ngModel)]="earmarked"
-      value="Earmarked">
+    <br />
+    <input id="goalBehaviorEarmarked" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="EARMARKED">
+    <label for="goalBehaviorEarmarked"
+    title="Earmarked goals are placed at the top of the list and try to reserve funds like they have already been purchased">
+      Earmarked ⓘ
+    </label>
+    <br />
+    <input id="goalBehaviorPaused" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="PAUSED">
+    <label for="goalBehaviorPaused"
+      title="Paused goals are skipped when adding funds, but will continue to safely loan funds they already have to other goals">
+      Paused ⓘ
+    </label>
   </div>
 
   <button

--- a/src/app/edit-goal-item/edit-goal-item.component.ts
+++ b/src/app/edit-goal-item/edit-goal-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
-import { Goal } from '../shared/models/goal.model';
+import { Goal, GoalBehavior } from '../shared/models/goal.model';
 import { Budgets } from '../shared/services/budgets.service';
 import { Budget } from '../shared/models/budget.model';
 
@@ -20,7 +20,7 @@ export class EditGoalItemComponent implements OnInit {
 
   public name: string;
   public target: number;
-  public earmarked = false;
+  public behavior = GoalBehavior.Default;
 
   constructor(private budgets: Budgets) { }
 
@@ -28,7 +28,7 @@ export class EditGoalItemComponent implements OnInit {
     if (this.goal !== undefined) {
       this.name = this.goal.label;
       this.target = parseFloat((this.goal.target / 100).toFixed(2));
-      this.earmarked = this.goal.earmarked;
+      this.behavior = this.goal.behavior;
     }
   }
 
@@ -39,7 +39,7 @@ export class EditGoalItemComponent implements OnInit {
     }
     goal.label = this.name;
     goal.target = Math.round(this.target * 100);
-    goal.earmarked = this.earmarked;
+    goal.behavior = this.behavior;
     goal.save();
 
     this.budgets.save(goal.budget);

--- a/src/app/goal-list-item/goal-list-item.component.html
+++ b/src/app/goal-list-item/goal-list-item.component.html
@@ -3,6 +3,7 @@
               'goal-item-funded': goal.isFunded(),
               'goal-item-overdrawn': goal.isOverdrawn(),
               'goal-item-affordable': goalAffordable(),
+              'goal-item-paused': goal.isPaused(),
               'goal-item-earmarked': goal.isEarmarked()}">
 
   <div class="goal-item-detail-bar">

--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -1,4 +1,4 @@
-import { Goal, IGoal, GoalStatus } from './goal.model';
+import { Goal, IGoal, GoalStatus, GoalBehavior } from './goal.model';
 import { roundRandom } from '../utils/round';
 import { setMembership } from '../utils/membership';
 
@@ -59,7 +59,7 @@ export class Budget implements IBudget {
         (liability.isOverdrawn()
         ) || (
           // Earmarked goals are liabilities for any non-purchased goal
-          !target.purchased && liability.earmarked
+          !target.purchased && liability.isEarmarked()
         )
         ))
     );
@@ -104,7 +104,7 @@ export class Budget implements IBudget {
     // loaners is a list of [available to lend, max per loan]
     const loaners: LoanerGoal[] = this.goals.filter(
       // Only use goals that haven't been purchased (That have savings to loan) and aren't funded (That don't need their savings directly)
-      goal => !goal.isPurchased() && !goal.isFunded() && (!goal.earmarked || (goal === recipient) || recipient.purchased)
+      goal => !goal.isPurchased() && !goal.isFunded() && (!goal.isEarmarked() || (goal === recipient) || recipient.purchased)
     ).map<LoanerGoal>(
       goal => ({
         goal: goal,

--- a/src/app/shared/models/goal.model.ts
+++ b/src/app/shared/models/goal.model.ts
@@ -82,7 +82,7 @@ export class IGoalV3 extends IGoalV1 {
       purchased: v2.purchased,
       closed: v2.closed,
       behavior: v2.earmarked ? GoalBehavior.Earmarked : GoalBehavior.Default,
-    }
+    };
   }
 }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -210,6 +210,10 @@ ul.budget-list {
   border: 2px solid #333;
 }
 
+.goal-item-paused .goal-item-detail-content {
+  color: #a0a0a0;
+}
+
 .budget-column:not(:last-child) {
   border-right: 1px solid #b0b0b0;
   border-top: 1px solid #b0b0b0;


### PR DESCRIPTION
- Allows goals to be paused, causing them to be skipped when adding funds.
- Converts selection of a goal's status to a radiobox selection, so that a goal can either be "Normal", "Earmarked", or "Paused"
  - Adds a tooltip to each item to describe the behavior described by each
- Disabled goals are automatically un-disabled if they are purchased while still disabled
- Grays the main line text of a disabled goal to indicate its status
- Adds a new `IGoalV3` interface that reverses a value added in `IGoalV2`. Goals will be upgraded automatically, but cannot be read by old versions of the code after upgrade.
  - Attempts to do so will result in a fatal error, preventing the page from working but should not result in corrupted data

<img width="552" alt="Screen Shot 2020-09-12 at 5 31 41 PM" src="https://user-images.githubusercontent.com/1032849/93005332-1d712600-f51e-11ea-98bc-c33ad0d21d7a.png">

Closes #27