### PR TITLE
Sort all goal types by target descending

### DIFF
--- a/src/app/shared/models/budget.model.ts
+++ b/src/app/shared/models/budget.model.ts
@@ -238,13 +238,8 @@ export class Budget implements IBudget {
       if (aStatus !== bStatus) {
         return aStatus - bStatus;
       }
-      if (aStatus === GoalStatus.Purchased) {
-        // Both are purchased, sort by remaining unfunded amount
-        return (a.target - a.current) - (b.target - b.current);
-      } else {
-        // Neither are purchased, sort by target
-        return b.target - a.target;
-      }
+      // For goals within the same grouping, sort by greatest target goal first
+      return b.target - a.target;
     });
   }
 }


### PR DESCRIPTION
Originally purchased but not fully allocated goals were sorted by remaining gap, so that goals closest to their target received the greatest share of an allocation with the goal of being fulfilled as quickly as possible.

This works well in cases where a purchased but not fully allocated goal occurs infrequently, but with the flexibility of the loaning logic it's become common that goals are most commonly purchased on margin. In that case, because the largest goals are kept from the top of the allocation process, there is a bias towards small goals - they are most readily able to be purchased on margin, and low value loans are most quickly replenished.

In order to attempt to balance this bias against large goals, this reverts the sorting logic to sort large goals first so that the large value loans they require receive the highest portion of allocations.