### PR TITLE
Only show Total Saved field if a budget exists

### DIFF
--- a/src/app/user-navbar/user-navbar.component.ts
+++ b/src/app/user-navbar/user-navbar.component.ts
@@ -10,9 +10,9 @@ export class UserNavbarComponent {
 
   constructor(public budgetsService: Budgets) {
     budgetsService.list().subscribe(budgets => {
-      this.totalSaved = budgets
+      this.totalSaved = budgets.length > 0 ? budgets
         .map(budget => budget.totalBalance())
-        .reduce((balance, sum) => sum + balance, 0);
+        .reduce((balance, sum) => sum + balance, 0) : undefined;
     });
 
   }


### PR DESCRIPTION
In #37 we add an element to display the total saved across all budgets, but it was discovered that this displays even when no user is logged in and no budgets are configured. This adds a check to only show the field if a budget has been created that could have a saved balance.

## Previous behavior
<img width="166" alt="Screen Shot 2021-02-13 at 9 02 07 PM" src="https://user-images.githubusercontent.com/1032849/107866424-c4941980-6e3e-11eb-8a7f-14cb1d174e07.png">

## New behavior
<img width="142" alt="Screen Shot 2021-02-13 at 8 59 40 PM" src="https://user-images.githubusercontent.com/1032849/107866413-9f071000-6e3e-11eb-9988-f65cd18538e2.png">

When budgets exist, the field still displays as expected:
<img width="244" alt="Screen Shot 2021-02-13 at 8 59 35 PM" src="https://user-images.githubusercontent.com/1032849/107866437-e5f50580-6e3e-11eb-918b-7ca2e582a6fa.png">
