### PR TITLE
Priority Goals

### DIFF
--- a/src/app/edit-goal-item/edit-goal-item.component.html
+++ b/src/app/edit-goal-item/edit-goal-item.component.html
@@ -25,9 +25,22 @@
       required>
   </span>
 
-  <div *ngIf="!this.goal?.purchased">
+  <div *ngIf="!this.goal?.purchased" class="goal-item-behavior-select">
     <strong>Goal Behavior</strong>
-    <br />
+
+    <p *ngIf="behavior === ''">
+      <em>Normal</em> goals will loan other goals funds safely, in a way that they can be purchased once fully funded
+    </p>
+    <p *ngIf="behavior === 'EARMARKED'">
+      <em>Earmarked</em> goals are placed above Normal goals in the budget and will preemptively reserve loans from other goals to simulate that they have been purchased
+    </p>
+    <p *ngIf="behavior === 'PRIORITY'">
+      <em>Priority</em> goals are ranked highest in the budget and do not loan to other goals, but do not preemptively reserve loans like Earmarked goals
+    </p>
+    <p *ngIf="behavior === 'PAUSED'">
+      <em>Paused</em> goals are skipped when adding funds, but will continue to safely loan funds they already have to other goals
+    </p>
+
     <input id="goalBehaviorDefault" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="">
     <label for="goalBehaviorDefault"
       title="By default, goals will loan other goals funds safely, in a way that they can be purchased once fully funded">
@@ -52,6 +65,8 @@
       Paused ⓘ
     </label>
   </div>
+
+  <br />
 
   <button
     type="submit"

--- a/src/app/edit-goal-item/edit-goal-item.component.html
+++ b/src/app/edit-goal-item/edit-goal-item.component.html
@@ -36,13 +36,13 @@
     <br />
     <input id="goalBehaviorEarmarked" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="EARMARKED">
     <label for="goalBehaviorEarmarked"
-    title="Earmarked goals are placed at the top of the list and try to reserve funds like they have already been purchased">
+    title="Earmarked goals are placed above Normal goals in the budget and will preemptively reserve loans from other goals to simulate that they have been purchased">
       Earmarked ⓘ
     </label>
     <br />
     <input id="goalBehaviorPriority" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="PRIORITY">
     <label for="goalBehaviorPriority"
-    title="Priority goals description TBD">
+    title="Priority goals are ranked highest in the budget and do not loan to other goals, but do not preemptively reserve loans like Earmarked goals">
       Priority ⓘ
     </label>
     <br />

--- a/src/app/edit-goal-item/edit-goal-item.component.html
+++ b/src/app/edit-goal-item/edit-goal-item.component.html
@@ -40,6 +40,12 @@
       Earmarked ⓘ
     </label>
     <br />
+    <input id="goalBehaviorPriority" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="PRIORITY">
+    <label for="goalBehaviorPriority"
+    title="Priority goals description TBD">
+      Priority ⓘ
+    </label>
+    <br />
     <input id="goalBehaviorPaused" type="radio" [(ngModel)]="behavior" name="goalBehavior" value="PAUSED">
     <label for="goalBehaviorPaused"
       title="Paused goals are skipped when adding funds, but will continue to safely loan funds they already have to other goals">

--- a/src/app/goal-list-item/goal-list-item.component.html
+++ b/src/app/goal-list-item/goal-list-item.component.html
@@ -4,7 +4,8 @@
               'goal-item-overdrawn': goal.isOverdrawn(),
               'goal-item-affordable': goalAffordable(),
               'goal-item-paused': goal.isPaused(),
-              'goal-item-earmarked': goal.isEarmarked()}">
+              'goal-item-earmarked': goal.isEarmarked(),
+              'goal-item-priority': goal.isPriority()}">
 
   <div class="goal-item-detail-bar">
     <div class="goal-item-detail-content">

--- a/src/app/shared/models/goal.model.ts
+++ b/src/app/shared/models/goal.model.ts
@@ -226,12 +226,12 @@ export class Goal implements IGoal {
   public status(): GoalStatus {
     if (this.isFunded()) {
       return GoalStatus.Funded;
-    } else if (this.isEarmarked()) {
-      return GoalStatus.Earmarked;
-    } else if (this.isPriority()) {
-      return GoalStatus.Priority;
     } else if (this.isPurchased()) {
-      return GoalStatus.Purchased;
+        return GoalStatus.Purchased;
+    } else if (this.behavior === GoalBehavior.Earmarked) {
+      return GoalStatus.Earmarked;
+    } else if (this.behavior === GoalBehavior.Priority) {
+      return GoalStatus.Priority;
     } else {
       return GoalStatus.Normal;
     }

--- a/src/app/shared/models/goal.model.ts
+++ b/src/app/shared/models/goal.model.ts
@@ -4,6 +4,7 @@ import { disperseBalance } from '../utils/dispersement';
 
 export enum GoalStatus {
   Funded,
+  Priority,
   Earmarked,
   Purchased,
   Normal
@@ -11,6 +12,7 @@ export enum GoalStatus {
 
 export enum GoalBehavior {
   Default = '',
+  Priority = 'PRIORITY',
   Paused = 'PAUSED',
   Earmarked = 'EARMARKED',
 }
@@ -213,6 +215,10 @@ export class Goal implements IGoal {
     return this.behavior === GoalBehavior.Earmarked && !this.isPurchased();
   }
 
+  public isPriority(): boolean {
+    return this.behavior === GoalBehavior.Priority && !this.isPurchased();
+  }
+
   public isPaused(): boolean {
     return this.behavior === GoalBehavior.Paused && !this.isPurchased();
   }
@@ -222,6 +228,8 @@ export class Goal implements IGoal {
       return GoalStatus.Funded;
     } else if (this.isEarmarked()) {
       return GoalStatus.Earmarked;
+    } else if (this.isPriority()) {
+      return GoalStatus.Priority;
     } else if (this.isPurchased()) {
       return GoalStatus.Purchased;
     } else {

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -50,8 +50,8 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
 
   const recipientStatus = recipient ? goalPrecedence(recipient) : LoanPrecedence.Normal;
 
-  // Non-normal goals only loan to goals at a higher precedence
-  return originStatus < recipientStatus;
+  // Non-normal goals loan to goals at the same or higher precedence
+  return recipientStatus >= originStatus;
 }
 
 function isLiabilityFor(liability: Goal, target?: Goal): boolean {

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -23,6 +23,9 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
     case GoalStatus.Normal:
       // Normal status goals are safe to loan to any other goal
       return true;
+    case GoalStatus.Funded:
+      // Funded goals don't have any funds available to loan
+      return false;
     case GoalStatus.Purchased:
       // Purchased goals have a negative balance and no capacity to issue loans
       return false;

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -12,8 +12,8 @@ interface Loaner {
   maxLoan: number;
 }
 
-
 enum LoanPrecedence {
+  Priority,
   Earmarked,
   Normal,
   Purchased,
@@ -22,6 +22,8 @@ enum LoanPrecedence {
 function goalPrecedence(goal: Goal): LoanPrecedence {
   if (goal.isEarmarked()) {
     return LoanPrecedence.Earmarked;
+  } else if (goal.isPriority()) {
+    return LoanPrecedence.Priority;
   } else if (goal.isPurchased()) {
     return LoanPrecedence.Purchased;
   } else {

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -67,7 +67,6 @@ function getLiabilities(budget: Budget, recipient?: Goal): Liability[] {
 
 function getLoaners(budget: Budget, recipient?: Goal): Loaner[] {
   return budget.goals.filter(
-    // Only use goals that haven't been purchased (That have savings to loan) and aren't funded (That don't need their savings directly)
     goal => canLoanTo(goal, recipient)
   ).map<Loaner>(
     goal => ({

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -29,7 +29,7 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
     default:
       // Earmarked and priority goals only loan to purchased goals
       const recipientStatus = recipient ? recipient.status() : GoalStatus.Normal;
-      return (recipientStatus === GoalStatus.Purchased)
+      return (recipientStatus === GoalStatus.Purchased);
   }
 }
 

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -35,7 +35,7 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
       const recipientStatus = recipient ? recipient.status() : GoalStatus.Normal;
       return (recipientStatus === GoalStatus.Purchased);
     default:
-      throw new Error(`Unexpected GoalStatus value ${originStatus}`)
+      throw new Error(`Unexpected GoalStatus value ${originStatus}`);
   }
 }
 

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -1,5 +1,5 @@
 import { Budget } from '../models/budget.model';
-import { Goal } from '../models/goal.model';
+import { Goal, GoalBehavior } from '../models/goal.model';
 
 interface Liability {
   goal: Goal;
@@ -20,12 +20,12 @@ enum LoanPrecedence {
 }
 
 function goalPrecedence(goal: Goal): LoanPrecedence {
-  if (goal.isEarmarked()) {
-    return LoanPrecedence.Earmarked;
-  } else if (goal.isPriority()) {
-    return LoanPrecedence.Priority;
-  } else if (goal.isPurchased()) {
+  if (goal.isPurchased()) {
     return LoanPrecedence.Purchased;
+  } else if (goal.behavior === GoalBehavior.Earmarked) {
+    return LoanPrecedence.Earmarked;
+  } else if (goal.behavior === GoalBehavior.Priority) {
+    return LoanPrecedence.Priority;
   } else {
     return LoanPrecedence.Normal;
   }

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -26,10 +26,13 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
     case GoalStatus.Purchased:
       // Purchased goals have a negative balance and no capacity to issue loans
       return false;
-    default:
+    case GoalStatus.Earmarked:
+    case GoalStatus.Priority:
       // Earmarked and priority goals only loan to purchased goals
       const recipientStatus = recipient ? recipient.status() : GoalStatus.Normal;
       return (recipientStatus === GoalStatus.Purchased);
+    default:
+      throw new Error(`Unexpected GoalStatus value ${originStatus}`)
   }
 }
 

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -1,5 +1,5 @@
 import { Budget } from '../models/budget.model';
-import { Goal, GoalBehavior, GoalStatus } from '../models/goal.model';
+import { Goal, GoalStatus } from '../models/goal.model';
 
 interface Liability {
   goal: Goal;
@@ -45,9 +45,9 @@ function isLiabilityFor(liability: Goal, target?: Goal): boolean {
       // Purchased goals are presumptive liabilities
       return true;
     case GoalStatus.Earmarked:
-      // Earmarked goals are liabilities for normal status goals
+      // Earmarked goals are a liability for any non-purchased goal
       const targetStatus = target ? target.status() : GoalStatus.Normal;
-      return (targetStatus === GoalStatus.Normal);
+      return (targetStatus !== GoalStatus.Purchased);
     default:
       // If the goal isn't purchased or earmarked, then it isn't a liability
       return false;

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -61,9 +61,16 @@ function isLiabilityFor(liability: Goal, target?: Goal): boolean {
   }
 
   const liabilityStatus = goalPrecedence(liability);
-  const targetStatus = target ? goalPrecedence(target) : LoanPrecedence.Normal;
+  if (liabilityStatus !== LoanPrecedence.Earmarked && liabilityStatus !== LoanPrecedence.Purchased) {
+    // Only purchased or earmarked goals can be liabilities
+    return false;
+  }
 
-  return liabilityStatus >= targetStatus;
+  // Liabilities apply to goals of a lower tier
+  // - Purchased goals are a liability for all non-purchased tiers
+  // - Earmarked goals are a liability for normal and priority goals
+  const targetStatus = target ? goalPrecedence(target) : LoanPrecedence.Normal;
+  return liabilityStatus > targetStatus;
 }
 
 function getLiabilities(budget: Budget, recipient?: Goal): Liability[] {

--- a/src/app/shared/utils/loaning.ts
+++ b/src/app/shared/utils/loaning.ts
@@ -13,9 +13,9 @@ interface Loaner {
 }
 
 enum LoanPrecedence {
+  Normal,
   Priority,
   Earmarked,
-  Normal,
   Purchased,
 }
 
@@ -36,22 +36,22 @@ function canLoanTo(origin: Goal, recipient?: Goal): boolean {
     // A goal can always "loan" to itself
     return true;
   }
-  if (origin.isFunded()) {
-    // A funded goal has zero loanable balance, so it effectively cannot loan
-    return false;
-  }
 
   const originStatus = goalPrecedence(origin);
 
   if (originStatus === LoanPrecedence.Normal) {
-    // Normal level goals can always loan to other goals
+    // Normal status goals are safe to loan to any other goal
     return true;
+  } else if (originStatus === LoanPrecedence.Purchased) {
+    // Purchased goals have a negative balance and cannot make loans
+    return false;
   }
 
+  // Other status goals can loan to goals of a higher tier than them...
+  // - Priority status goals can loan to earmarked or purchased goals,
+  // - Earmarked goals can loan only to purchased goals.
   const recipientStatus = recipient ? goalPrecedence(recipient) : LoanPrecedence.Normal;
-
-  // Non-normal goals loan to goals at the same or higher precedence
-  return recipientStatus >= originStatus;
+  return recipientStatus > originStatus;
 }
 
 function isLiabilityFor(liability: Goal, target?: Goal): boolean {

--- a/src/styles.css
+++ b/src/styles.css
@@ -215,6 +215,10 @@ ul.budget-list {
   border: 2px solid #333;
 }
 
+.goal-item-priority {
+  background: linear-gradient(90deg, #FFDB99 0, #FFF3DE 40%);
+}
+
 .goal-item-paused .goal-item-detail-content {
   color: #a0a0a0;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -216,7 +216,11 @@ ul.budget-list {
 }
 
 .goal-item-priority {
-  background: linear-gradient(90deg, #FFDB99 0, #FFF3DE 40%);
+  background: linear-gradient(90deg, #FFDB99 0, #fdeac7 30%);
+}
+
+.goal-item-affordable.goal-item-priority {
+  background: linear-gradient(90deg, #FFDB99 0, #e0dff0 30%);
 }
 
 .goal-item-paused .goal-item-detail-content {

--- a/src/styles.css
+++ b/src/styles.css
@@ -227,6 +227,21 @@ ul.budget-list {
   color: #a0a0a0;
 }
 
+.goal-item-behavior-select {
+  margin-top: 0.3rem;
+}
+
+.goal-item-behavior-select p {
+  margin-top: 0.3rem;
+  margin-bottom: 0.3rem;
+}
+
+.goal-item-behavior-select em {
+  font-weight: bold;
+  font-style: normal;
+  color: #333;
+}
+
 .budget-column:not(:last-child) {
   border-right: 1px solid #b0b0b0;
   border-top: 1px solid #b0b0b0;


### PR DESCRIPTION
introduces a third mode for goals, between the default mode and earmarked. Goals in this mode will be ranked top of the budget and will withhold their balance from loans to other goals, but will not reserve incoming loans from other goals like earmarked.

<img width="550" alt="Screen Shot 2021-03-01 at 9 44 50 PM" src="https://user-images.githubusercontent.com/1032849/109588830-5c4c6580-7ad7-11eb-8870-4ba213c3057f.png">

The use case for this is for accelerating goals that are high-cost goals but may not be needed imminently. The reason for withholding balance from loans to other goals is that they rank above purchased goals, and accumulation slows as goals rank lower. If the priority goals did not reserve their balance from other goals the budget may not be able to be ensure that the goal's balance is available once the goal reaches full funding.